### PR TITLE
Fix Maven build for lsp.core and lsp.ui

### DIFF
--- a/common/org.eclipse.tracecompass.incubator.releng-site/.project
+++ b/common/org.eclipse.tracecompass.incubator.releng-site/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.UpdateSiteNature</nature>
 	</natures>
 </projectDescription>

--- a/common/org.eclipse.tracecompass.incubator.target/.project
+++ b/common/org.eclipse.tracecompass.incubator.target/.project
@@ -5,7 +5,13 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.atrace.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.atrace.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.callstack.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.callstack.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.eventfieldcount.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.eventfieldcount.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.ftrace.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.ftrace.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.kernel.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.kernel.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.lsp.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.lsp.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.lttng2.ust.extras.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.lttng2.ust.extras.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.opentracing.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.opentracing.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.perf.profiling.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.perf.profiling.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.ros.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.ros.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.trace.server.doc.dev/.project
+++ b/doc/org.eclipse.tracecompass.incubator.trace.server.doc.dev/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.uftrace.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.uftrace.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/org.eclipse.tracecompass.incubator.virtual.machine.analysis.doc.user/.project
+++ b/doc/org.eclipse.tracecompass.incubator.virtual.machine.analysis.doc.user/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<triggers>clean,full,incremental,</triggers>
 			<arguments>
@@ -29,9 +34,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.mylyn.wikitext.ui.wikiTextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -43,8 +43,6 @@
     <module>org.eclipse.tracecompass.incubator.ros.doc.user</module>
     <module>org.eclipse.tracecompass.incubator.lsp.doc.user</module>
     <module>org.eclipse.tracecompass.incubator.eventfieldcount.doc.user</module>
-    <module>org.eclipse.tracecompass.incubator.temp.doc.user</module>
-    <module>org.eclipse.tracecompass.incubator.temp.doc.user</module>
     <!-- insert modules here -->
   </modules>
 

--- a/lsp/org.eclipse.tracecompass.incubator.lsp.core/META-INF/MANIFEST.MF
+++ b/lsp/org.eclipse.tracecompass.incubator.lsp.core/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.tracecompass.common.core,
+ org.eclipse.jdt.annotation,
  org.eclipse.lsp4j;bundle-version="0.4.1",
  org.eclipse.lsp4j.jsonrpc;bundle-version="0.4.1",
  com.google.gson;bundle-version="2.7.0"

--- a/lsp/org.eclipse.tracecompass.incubator.lsp.core/src/org/eclipse/tracecompass/incubator/internal/lsp/core/server/LSPServer.java
+++ b/lsp/org.eclipse.tracecompass.incubator.lsp.core/src/org/eclipse/tracecompass/incubator/internal/lsp/core/server/LSPServer.java
@@ -18,7 +18,7 @@ import java.net.Socket;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.launch.LSPLauncher;
 import org.eclipse.lsp4j.services.LanguageClient;
-import org.eclipse.lsp4j.services.LanguageServer;
+// import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.tracecompass.incubator.internal.lsp.core.Activator;
 import org.eclipse.tracecompass.incubator.internal.lsp.core.shared.Configuration;
 
@@ -54,7 +54,7 @@ public class LSPServer {
      */
     public LSPServer(InputStream in, OutputStream out) {
         fLSPServer = new LanguageFilterServer();
-        LanguageServer ls = new LanguageFilterServer();
+        // LanguageServer ls = new LanguageFilterServer();
         Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(fLSPServer, in, out);
         fLSPServer.connect(launcher.getRemoteProxy());
         launcher.startListening();

--- a/lsp/org.eclipse.tracecompass.incubator.lsp.ui/META-INF/MANIFEST.MF
+++ b/lsp/org.eclipse.tracecompass.incubator.lsp.ui/META-INF/MANIFEST.MF
@@ -13,8 +13,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.tracecompass.common.core,
  org.eclipse.tracecompass.incubator.lsp.core,
  org.eclipse.lsp4j,
- org.eclipse.lsp4j.jsonrpc
+ org.eclipse.lsp4j.jsonrpc,
+ org.eclipse.jface.text,
+ org.eclipse.jdt.annotation
 Export-Package: org.eclipse.tracecompass.incubator.internal.lsp.ui;x-internal:=true,
  org.eclipse.tracecompass.incubator.lsp.ui.lspFilterTextbox
 Automatic-Module-Name: org.eclipse.tracecompass.incubator.lsp.ui
-Import-Package: org.eclipse.jface.text

--- a/lsp/org.eclipse.tracecompass.incubator.lsp.ui/build.properties
+++ b/lsp/org.eclipse.tracecompass.incubator.lsp.ui/build.properties
@@ -13,5 +13,4 @@ bin.includes = META-INF/,\
                .,\
                about.html,\
                plugin.properties
-additional.bundles = org.eclipse.jdt.annotation
 jars.extra.classpath = platform:/plugin/org.eclipse.jdt.annotation

--- a/lsp/org.eclipse.tracecompass.incubator.lsp.ui/src/org/eclipse/tracecompass/incubator/lsp/ui/lspFilterTextbox/LspFilterTextbox.java
+++ b/lsp/org.eclipse.tracecompass.incubator.lsp.ui/src/org/eclipse/tracecompass/incubator/lsp/ui/lspFilterTextbox/LspFilterTextbox.java
@@ -36,7 +36,7 @@ import org.eclipse.lsp4j.ColorInformation;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.TextEdit;
+// import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.tracecompass.incubator.internal.lsp.core.client.LSPFilterClient;
 import org.eclipse.tracecompass.incubator.internal.lsp.core.shared.LspObserver;
@@ -305,8 +305,8 @@ public class LspFilterTextbox implements LspObserver {
                     // TODO: Needs to be implemented
                     List<CompletionItem> completions = completion.getLeft();
                     for (int i = 0; i < completions.size(); i++) {
-                        TextEdit textEdit = completions.get(i).getTextEdit();
-                        String suggestion = textEdit.getNewText();
+                        // TextEdit textEdit = completions.get(i).getTextEdit();
+                        // String suggestion = textEdit.getNewText();
                     }
                 }
             });

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,7 @@
 
   <modules>
     <module>common</module>
+    <module>lsp</module>
     <module>analyses</module>
     <module>callstack</module>
     <module>vm</module>


### PR DESCRIPTION
This also fixes the "mvn install" compile error with @Nullable generating API errors
Comment out unused code to quiet Maven errors before pushing dropdown feature
Adds lsp folder to the root project pom.xml
lsp.core.tests still won't build on Maven.